### PR TITLE
Fix documentation references

### DIFF
--- a/docs/PR/post_test_analysis_plan.md
+++ b/docs/PR/post_test_analysis_plan.md
@@ -57,7 +57,7 @@ Based on the test results, the following areas require attention:
         *   Verify the `CalculateScore` method of the `ScoreCalculator` (likely `DefaultScoreCalculator`) returns the expected score and confidence based on the test's input `LLMScore` data.
         *   Check `ProgressManager` interactions within `ScoreManager` to ensure status, step, and percentage are updated as expected by the test.
         *   **`TestIntegrationUpdateArticleScoreCalculationError` & `TestScoreManagerIntegrationCalculateScoreError`:** Examine how errors from `ScoreCalculator.CalculateScore` are propagated and handled within `ScoreManager.UpdateArticleScore`. Ensure error messages are correctly set in `ProgressManager` and that the overall function returns an error that matches the test's expectation.
-- **Supporting Documentation:** `docs/pr/todo_llm_test_fixes.md` already outlines a plan for LLM test fixes, which should be consulted and updated.
+ - **Supporting Documentation:** A dedicated LLM test fixes plan should be created and referenced here.
 
 ### 2.2 Medium Priority: `scripts/test.cmd` Script Error
 

--- a/docs/PR/test_system_analysis.md
+++ b/docs/PR/test_system_analysis.md
@@ -7,7 +7,7 @@ This document provides a comprehensive analysis of the NewsBalancer Go project's
 *   Significant failures in API integration tests due to mock setup issues (`GetConfig`).
 *   Build failures in `internal/llm` and `internal/testing`.
 
-The subsequent review, incorporating insights from `docs/testing.md`, has allowed for a more refined prioritization of fixes and improvements. The strengths of this combined analysis include accurate identification of critical blockers and sound recommendations. Minor refinements could involve more explicit cross-referencing with related documents like `docs/pr/todo_llm_test_fixes.md`. The following sections detail the findings and a prioritized action plan.
+The subsequent review, incorporating insights from `docs/testing.md`, has allowed for a more refined prioritization of fixes and improvements. The strengths of this combined analysis include accurate identification of critical blockers and sound recommendations. Minor refinements could involve more explicit cross-referencing with a planned document on LLM test fixes. The following sections detail the findings and a prioritized action plan.
 
 ## 1. Test Coverage Overview
 
@@ -109,8 +109,8 @@ The test coverage across the system is uneven:
     *   **Action:** Implement `mockLLMClient.On("GetConfig").Return(...)` in `setupIntegrationTestServer` (`internal/api/api_integration_test.go`) and other affected tests, returning a valid `*llm.CompositeScoreConfig`.
     *   **Rationale:** Unblocks a large number of failing Go integration tests, providing a clearer view of API health.
 
-3.  **Fix `internal/llm` Unit Test Failures (Ref: `docs/testing.md` - Current Test Status; `docs/pr/todo_llm_test_fixes.md`)**
-    *   **Action:** Address failing unit tests in `internal/llm` as per `todo_llm_test_fixes.md`.
+3.  **Fix `internal/llm` Unit Test Failures (Ref: `docs/testing.md` - Current Test Status)**
+    *   **Action:** Address failing unit tests in `internal/llm` as outlined in the future LLM test fixes document.
     *   **Rationale:** LLM is core functionality; failing unit tests indicate potential logic bugs.
 
 ### P1: High Priority (Address after P0 to stabilize core testing and cover essential functionality)

--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -156,11 +156,10 @@ func TestSomething(t *testing.T) {
 The test framework creates an in-memory SQLite database by default. For persistent tests, you can:
 
 ```bash
-# Reset the test database
+# Reset the test database (PowerShell)
 ./recreate_db.ps1  # Windows
-./recreate_db.sh   # Linux/macOS
 
-# Manually clear specific test data
+# Manually clear specific test data or recreate the DB on other platforms
 go run cmd/reset_test_db/main.go
 ```
 

--- a/docs/plans/test_coverage_plan.md
+++ b/docs/plans/test_coverage_plan.md
@@ -69,14 +69,14 @@
 - **Tasks:**
   - [x] Use gomock or testify for DB/LLM mocks (see mock_llm_service.go, internal/api/api_test.go)
   - [ ] Ensure all mocks implement interfaces (see internal/db/interfaces.go)
-  - [ ] Document mock usage patterns (see TESTING_GUIDE.md)
+  - [ ] Document mock usage patterns (see docs/testing.md)
   - [x] Use test data directories and snapshotting for E2E (see e2e_prep.js)
 
 ## 6. Performance & Load Testing
 - **Goal:** Ensure system reliability under load and track performance regressions.
 - **Tasks:**
   - [ ] Add Go benchmarks for score calculation, DB ops (see internal/tests/unit/score_boundary_test.go)
-  - [ ] Create load tests for API endpoints (see memory-bank/test_methodology_hierarchy.md)
+  - [ ] Create load tests for API endpoints (plan forthcoming)
   - [ ] Track API response times and add regression alerts
 
 ## 7. Reporting & CI Integration
@@ -90,17 +90,15 @@
 ## 8. Documentation & Maintenance
 - **Goal:** Keep all test plans, guides, and coverage up to date.
 - **Tasks:**
-  - [ ] Document test requirements and setup (see TESTING_GUIDE.md, CLI_TESTING_GUIDE.md)
+  - [ ] Document test requirements and setup (see docs/testing.md)
   - [x] Update test_coverage_todo.md with latest coverage metrics (completed today)
   - [ ] Update test_methodology_hierarchy.md to reflect current testing priorities
 
 ---
 
 For detailed test case design, edge case handling, and automation, see:
-- [archive/postman_rescoring_test_plan.md](memory-bank/archive/postman_rescoring_test_plan.md)
-- [test_methodology_hierarchy.md](memory-bank/test_methodology_hierarchy.md)
-- [CLI_TESTING_GUIDE.md](CLI_TESTING_GUIDE.md)
-- [TESTING_GUIDE.md](TESTING_GUIDE.md)
+- Documentation in `docs/PR/` for past analysis and proposals
+- The main [Testing Guide](../testing.md)
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ This document provides information on how to test the NewsBalancer Go applicatio
 
 ## Recent Improvements
 
-Based on recent debugging efforts (documented in `docs/pr/`), the following improvements have been made:
+Based on recent debugging efforts (documented in `docs/PR/`), the following improvements have been made:
 
 1. **Schema Fix**: Added `UNIQUE(article_id, model)` constraint to the `llm_scores` table to fix SQL `ON CONFLICT` issues
 2. **Enhanced Documentation**: Detailed troubleshooting steps for common test failures
@@ -73,7 +73,7 @@ For successful test execution:
 
 ## Root Causes of Common Failures
 
-Based on recent debugging (see `docs/pr/test_fixes_summary.md`), we identified two primary issues that cause test failures:
+Based on recent debugging (see `docs/PR/test_system_analysis.md`), we identified two primary issues that cause test failures:
 
 1. **SQL Schema Constraint Mismatch**: Without a `UNIQUE(article_id, model)` constraint on the `llm_scores` table, SQL `ON CONFLICT` clauses fail with:
    ```


### PR DESCRIPTION
## Summary
- fix references to docs/PR in testing guide
- remove links to non-existent files in test coverage plan
- clarify TODO references in test system docs
- adjust integration testing database instructions

## Testing
- `go test ./...` *(fails: no route to host)*