### PR TITLE
Add coverage badge and artifact upload

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run Go unit and integration tests (NO_AUTO_ANALYZE=true)
       run: |
         export NO_AUTO_ANALYZE=true
-        go test -v ./...
+        go test -v -coverprofile=coverage.out ./...
 
     - name: Run full API/integration test suite (scripts/test.sh all)
       if: runner.os == 'Linux'
@@ -41,6 +41,23 @@ jobs:
       with:
         name: test-results
         path: test-results/
+    - name: Generate coverage summary
+      run: |
+        go tool cover -func=coverage.out -o coverage-summary.txt
+
+    - name: Generate coverage badge
+      uses: go-coverage/go-coverage-badge@v1
+      with:
+        coverage-file: coverage.out
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: |
+          coverage.out
+          coverage-summary.txt
+          coverage-badge.svg
 
     # To enable OpenAI live integration test, uncomment and set these secrets or env vars:
     # env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # NewsBalancer Go Backend
+![Coverage](https://go-coverage-badge.appspot.com/badge/github.com/alexandru-savinov/BalancedNewsGo.svg)
+
 
 A Go-based backend service that provides politically balanced news aggregation using LLM-based analysis.
 


### PR DESCRIPTION
## Summary
- output coverage during Go test step
- generate coverage badge via go-coverage-badge action
- upload coverage artifacts
- show coverage badge in README

## Testing
- `go test ./...`
