### PR TITLE
Implement caching for feed health and score updates

### DIFF
--- a/internal/api/feed_health_cache_test.go
+++ b/internal/api/feed_health_cache_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type feedHealthMock struct{ mock.Mock }
+
+func (m *feedHealthMock) ManualRefresh() { m.Called() }
+func (m *feedHealthMock) CheckFeedHealth() map[string]bool {
+	args := m.Called()
+	if val, ok := args.Get(0).(map[string]bool); ok {
+		return val
+	}
+	return nil
+}
+
+func TestFeedHealthHandlerCaching(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	articlesCache = NewSimpleCache()
+
+	mockRSS := &feedHealthMock{}
+	result := map[string]bool{"feed1": true}
+	mockRSS.On("CheckFeedHealth").Return(result).Once()
+
+	router := gin.New()
+	router.GET("/healthz", feedHealthHandler(mockRSS))
+
+	req, _ := http.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Second call should use cache
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	mockRSS.AssertExpectations(t)
+}
+
+func TestFeedHealthCacheInvalidatedOnRefresh(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	articlesCache = NewSimpleCache()
+
+	mockRSS := &feedHealthMock{}
+	result := map[string]bool{"feed1": true}
+	mockRSS.On("CheckFeedHealth").Return(result).Twice()
+	mockRSS.On("ManualRefresh").Return().Once()
+
+	router := gin.New()
+	router.GET("/healthz", feedHealthHandler(mockRSS))
+	router.POST("/refresh", refreshHandler(mockRSS))
+
+	req, _ := http.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	reqRefresh, _ := http.NewRequest("POST", "/refresh", nil)
+	wRef := httptest.NewRecorder()
+	router.ServeHTTP(wRef, reqRefresh)
+	time.Sleep(10 * time.Millisecond)
+
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	mockRSS.AssertExpectations(t)
+}

--- a/internal/api/manual_score_handler_cache_test.go
+++ b/internal/api/manual_score_handler_cache_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alexandru-savinov/BalancedNewsGo/internal/db"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockInvalidator struct{ mock.Mock }
+
+func (m *mockInvalidator) InvalidateScoreCache(id int64) { m.Called(id) }
+
+func TestManualScoreHandlerInvalidatesCache(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockDB := &MockDBOperations{}
+	invalidator := &mockInvalidator{}
+
+	articleID := int64(42)
+	mockDB.On("FetchArticleByID", mock.Anything, articleID).Return(&db.Article{ID: articleID}, nil)
+	mockDB.On("UpdateArticleScore", mock.Anything, articleID, 0.5, 1.0).Return(nil)
+	invalidator.On("InvalidateScoreCache", articleID).Return()
+
+	router := gin.New()
+	router.POST("/manual-score/:id", SafeHandler(manualScoreHandler(mockDB, invalidator)))
+
+	body := bytes.NewBufferString(`{"score":0.5}`)
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/manual-score/%d", articleID), body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	invalidator.AssertCalled(t, "InvalidateScoreCache", articleID)
+}

--- a/internal/llm/score_manager.go
+++ b/internal/llm/score_manager.go
@@ -155,6 +155,7 @@ func (sm *ScoreManager) InvalidateScoreCache(articleID int64) {
 		fmt.Sprintf("article:%d", articleID),
 		fmt.Sprintf("ensemble:%d", articleID),
 		fmt.Sprintf("bias:%d", articleID),
+		fmt.Sprintf("summary:%d", articleID),
 	}
 	for _, key := range keys {
 		sm.cache.Delete(key)


### PR DESCRIPTION
## Summary
- cache feed health responses and bust cache on refresh
- allow manual score updates to invalidate score caches
- delete summary cache when LLM scores are updated
- add unit tests covering new caching logic

## Testing
- `go test ./...`