### PR TITLE
Add sources endpoint and query

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -479,6 +479,28 @@ paths:
       summary: Submit user feedback
       tags:
       - Feedback
+  /api/sources:
+    get:
+      consumes:
+      - application/json
+      description: Retrieves a list of unique news sources from the system
+      operationId: getNewsSources
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of news sources
+          schema:
+            items:
+              type: string
+            type: array
+        "500":
+          description: Server error
+          schema:
+            $ref: '#/definitions/internal_api.ErrorResponse'
+      summary: Get news sources
+      tags:
+      - Articles
   /api/feeds/healthz:
     get:
       consumes:

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -204,6 +204,18 @@ func (m *MockDBOperations) UpdateArticleScoreLLM(ctx context.Context, articleID 
 	return args.Error(0)
 }
 
+func (m *MockDBOperations) FetchDistinctSources(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	val, ok := args.Get(0).([]string)
+	if !ok {
+		return nil, args.Error(1)
+	}
+	return val, args.Error(1)
+}
+
 // Test helper functions
 func setupTestRouter(mock db.DBOperations) *gin.Engine {
 	gin.SetMode(gin.TestMode)

--- a/internal/api/get_sources_handler_test.go
+++ b/internal/api/get_sources_handler_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexandru-savinov/BalancedNewsGo/internal/db"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupSourcesTestDB(t *testing.T) *sqlx.DB {
+	dbConn, err := db.InitDB(":memory:")
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() { dbConn.Close() })
+	return dbConn
+}
+
+func TestGetSourcesHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	articlesCache = NewSimpleCache()
+	dbConn := setupSourcesTestDB(t)
+
+	// Insert initial data
+	articles := []db.Article{
+		{Source: "CNN", PubDate: time.Now(), URL: "http://cnn.com/1", Title: "t1", Content: "c1", CreatedAt: time.Now()},
+		{Source: "BBC", PubDate: time.Now(), URL: "http://bbc.com/1", Title: "t2", Content: "c2", CreatedAt: time.Now()},
+	}
+	for i := range articles {
+		_, err := db.InsertArticle(dbConn, &articles[i])
+		assert.NoError(t, err)
+	}
+
+	router := gin.New()
+	router.GET("/api/sources", SafeHandler(getSourcesHandler(dbConn)))
+
+	req, _ := http.NewRequest("GET", "/api/sources", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "CNN")
+	assert.Contains(t, w.Body.String(), "BBC")
+
+	// Add new article after first call
+	_, err := db.InsertArticle(dbConn, &db.Article{Source: "NYT", PubDate: time.Now(), URL: "http://nyt.com/1", Title: "t3", Content: "c3", CreatedAt: time.Now()})
+	assert.NoError(t, err)
+
+	// Second call should use cache and not include NYT
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.NotContains(t, w2.Body.String(), "NYT")
+}

--- a/internal/db/distinct_sources_test.go
+++ b/internal/db/distinct_sources_test.go
@@ -1,0 +1,34 @@
+package db_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alexandru-savinov/BalancedNewsGo/internal/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchDistinctSources(t *testing.T) {
+	dbConn := openTestDB(t)
+
+	// Empty DB should return empty slice
+	sources, err := db.FetchDistinctSources(dbConn)
+	assert.NoError(t, err)
+	assert.Empty(t, sources)
+
+	// Insert some articles with duplicate and empty sources
+	articles := []db.Article{
+		{Source: "CNN", PubDate: time.Now(), URL: "http://cnn.com/1", Title: "t1", Content: "c1", CreatedAt: time.Now()},
+		{Source: "BBC", PubDate: time.Now(), URL: "http://bbc.com/1", Title: "t2", Content: "c2", CreatedAt: time.Now()},
+		{Source: "CNN", PubDate: time.Now(), URL: "http://cnn.com/2", Title: "t3", Content: "c3", CreatedAt: time.Now()},
+		{Source: "", PubDate: time.Now(), URL: "http://empty.com", Title: "t4", Content: "c4", CreatedAt: time.Now()},
+	}
+	for i := range articles {
+		_, err := db.InsertArticle(dbConn, &articles[i])
+		assert.NoError(t, err)
+	}
+
+	sources, err = db.FetchDistinctSources(dbConn)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"BBC", "CNN"}, sources)
+}


### PR DESCRIPTION
## Summary
- add `FetchDistinctSources` DB query
- expose `getSourcesHandler` with caching
- register `/api/sources` route
- document endpoint in swagger spec
- test DB query and handler

## Testing
- `go test ./...`