### PR TITLE
Fix test log path and coverage badge action

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -46,7 +46,7 @@ jobs:
         go tool cover -func=coverage.out -o coverage-summary.txt
 
     - name: Generate coverage badge
-      uses: go-coverage/go-coverage-badge@v1
+      uses: go-coverage/go-coverage-badge@v1.0.1
       with:
         coverage-file: coverage.out
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Directory to store test outputs
-RESULTS_DIR="test-results"
+# Directory to store test outputs (allow override via env var)
+RESULTS_DIR="${RESULTS_DIR:-test-results}"
 # Create test-results directory if it doesn't exist
 mkdir -p "$RESULTS_DIR"
 


### PR DESCRIPTION
## Summary
- define `RESULTS_DIR` in `scripts/test.sh` and create the directory
- pin coverage badge action to v1.0.1 in CI workflow

## Testing
- `go test ./...`
