### PR TITLE
Remove llm_coverage in clean tool

### DIFF
--- a/tools/clean/main.go
+++ b/tools/clean/main.go
@@ -33,5 +33,10 @@ func main() {
 		}
 	}
 
+	// Remove llm_coverage file if present
+	if err := os.Remove("llm_coverage"); err != nil && !os.IsNotExist(err) {
+		fmt.Printf("Warning: Could not remove llm_coverage: %v\n", err)
+	}
+
 	fmt.Println("Clean operation complete")
 }


### PR DESCRIPTION
## Summary
- extend the cleanup utility to delete the root `llm_coverage` file if present

## Testing
- `bash run_test.sh`

------
https://chatgpt.com/codex/tasks/task_b_6841837dd68483248ab97db5e268a97e