### PR TITLE
Fix default golangci-lint path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ endif
 
 # Go / tools
 GO              := go
-GOLANGCI        := C:\Users\Alexander.Savinov\go\bin\golangci-lint.exe
+# Allow overriding the golangci-lint binary via environment variable.
+# Defaults to simply invoking `golangci-lint` from the PATH.
+GOLANGCI        ?= golangci-lint
 SWAG            := swag
 
 # Paths


### PR DESCRIPTION
## Summary
- clean up `GOLANGCI` variable
- default to `golangci-lint` so an environment override can be used

## Testing
- `bash run_test.sh > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_684183be83588324854e85cf65316518