### PR TITLE
Use env variable for Prometheus target

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -6,4 +6,4 @@ global:
 scrape_configs:
   - job_name: 'balancednewsgo'
     static_configs:
-      - targets: ['localhost:9090'] # Update with your application's metrics endpoint
+      - targets: ['${METRICS_TARGET}'] # Set your metrics endpoint via METRICS_TARGET env var


### PR DESCRIPTION
## Summary
- reference `${METRICS_TARGET}` for monitoring target

## Testing
- `bash run_test.sh`

------
https://chatgpt.com/codex/tasks/task_b_684183cda9448324869b8a30c38cba45