### PR TITLE
Fix run_tc3_debug portable path

### DIFF
--- a/scripts/run_tc3_debug.cmd
+++ b/scripts/run_tc3_debug.cmd
@@ -1,5 +1,7 @@
 @echo off
-cd /d C:\Users\user\Documents\dev\news_filter\newbalancer_go
+REM Change directory to the repository root relative to this script so
+REM it works from any checkout location.
+cd /d %~dp0..
 npx newman run memory-bank/postman_rescoring_collection.json --folder "TC3 - Rescore with Invalid Score (Out of Range)" --reporters cli,json --reporter-json-export test-results/tc3_rescore_invalid_score.json
 echo TC3 test completed. Results saved to test-results/tc3_rescore_invalid_score.json
 pause


### PR DESCRIPTION
## Summary
- make the Windows debug script use a relative path

## Testing
- `bash run_test.sh`

------
https://chatgpt.com/codex/tasks/task_b_684183f4a6a4832480259c4e872ad824