### PR TITLE
Add minimal template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ internal/db/*.db*
 # Test output text files
 *test_output*.txt
 test_results.txt
+!web/templates/*.html

--- a/README.md
+++ b/README.md
@@ -460,6 +460,13 @@ make run
 This will start the server on port 8080 by default. You can then access the web interface at http://localhost:8080.
 *Note: If you encounter a "port already in use" error (e.g., `listen tcp :8080: bind: Only one usage of each socket address...`), ensure no other processes are using port 8080. See "Port Conflicts" under "Common Test Issues and Solutions" above.*
 
+### Maintaining HTML Templates
+
+The application renders its frontend using Go templates stored in `web/templates/`. These follow the layout described in [FRONTEND_PROPOSAL.md](web/FRONTEND_PROPOSAL.md) and are loaded with `router.LoadHTMLGlob("web/templates/*.html")`. Edit `articles.html`, `article.html`, or `admin.html` and restart the server to see changes. Assets referenced from these files are served under `/static/`.
+
+When adding new template files, ensure the glob in `cmd/server/main.go` still matches their location.
+
+
 ## License
 
 Licensed under the [MIT License](LICENSE).

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ .Title }}</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+    <script type="module" src="/static/js/pages/admin.js"></script>
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/articles">Home</a> |
+        <a href="/admin">Admin</a>
+    </nav>
+    <h1>Admin Dashboard</h1>
+</header>
+<main>
+    <section class="system-stats">
+        <h2>System Stats</h2>
+        <ul>
+            <li>Total Articles: {{ .SystemStats.TotalArticles }}</li>
+            <li>Total Sources: {{ .SystemStats.TotalSources }}</li>
+            <li>Last Update: {{ .SystemStats.LastUpdate }}</li>
+        </ul>
+    </section>
+    <section class="metrics">
+        <h2>Metrics</h2>
+        <ul>
+            <li>Article Processing Rate: {{ .Metrics.ArticleProcessingRate }}</li>
+            <li>Average Response Time: {{ .Metrics.AvgResponseTime }}</li>
+            <li>Error Rate: {{ .Metrics.ErrorRate }}</li>
+            <li>Cache Hit Rate: {{ .Metrics.CacheHitRate }}</li>
+        </ul>
+    </section>
+</main>
+<footer>
+    <p>&copy; 2025 NewsBalancer</p>
+</footer>
+</body>
+</html>

--- a/web/templates/article.html
+++ b/web/templates/article.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ .Title }}</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+    <script type="module" src="/static/js/pages/article-detail.js"></script>
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/articles">Home</a> |
+        <a href="/admin">Admin</a>
+    </nav>
+    <h1>NewsBalancer</h1>
+</header>
+<main>
+    {{ if .Article }}
+    <article>
+        <h2>{{ .Article.Title }}</h2>
+        <div>{{ .Article.Source }} | {{ .Article.FormattedDate }} | {{ .Article.BiasLabel }}</div>
+        <div class="article-content">{{ .Article.Content }}</div>
+    </article>
+    {{ else }}
+    <p>Article not found.</p>
+    {{ end }}
+</main>
+<aside>
+    <h2>Recent Articles</h2>
+    <ul>
+        {{ range .RecentArticles }}
+        <li><a href="/article/{{ .ID }}">{{ .Title }}</a></li>
+        {{ end }}
+    </ul>
+</aside>
+<footer>
+    <p>&copy; 2025 NewsBalancer</p>
+</footer>
+</body>
+</html>

--- a/web/templates/articles.html
+++ b/web/templates/articles.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ .Title }}</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+    <script type="module" src="/static/js/pages/articles.js"></script>
+</head>
+<body>
+<header>
+    <nav>
+        <a href="/articles">Home</a> |
+        <a href="/admin">Admin</a>
+    </nav>
+    <h1>NewsBalancer</h1>
+</header>
+<section class="search-bar">
+    <form method="get" action="/articles">
+        <input type="text" name="query" placeholder="Search" value="{{ .Filters.Query }}" id="search-input">
+        <button type="submit">Search</button>
+    </form>
+</section>
+<main>
+    {{ if .Articles }}
+    <ul class="article-list" id="articles-container">
+        {{ range .Articles }}
+        <li>
+            <a href="/article/{{ .ID }}">{{ .Title }}</a>
+            <div>{{ .FormattedDate }} | {{ .Source }} | {{ .BiasLabel }}</div>
+            <p>{{ .Excerpt }}</p>
+        </li>
+        {{ end }}
+    </ul>
+    {{ else }}
+    <p>No articles found.</p>
+    {{ end }}
+</main>
+<aside>
+    <h2>Recent Articles</h2>
+    <ul>
+        {{ range .RecentArticles }}
+        <li><a href="/article/{{ .ID }}">{{ .Title }}</a></li>
+        {{ end }}
+    </ul>
+</aside>
+<footer>
+    <p>&copy; 2025 NewsBalancer</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add web templates for articles, article detail and admin pages
- unignore templates in `.gitignore`
- document how templates are maintained

## Testing
- `go test ./...`
- ran server locally and viewed `/articles`

------
https://chatgpt.com/codex/tasks/task_b_6841858d6d088324884d0efde5de974f