### PR TITLE
Add configurable package coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ Additionally, the database schema includes a `UNIQUE(article_id, model)` constra
   # Linux/macOS
   scripts/test.sh clean
   ```
+- Run coverage analysis (supports custom packages):
+  ```bash
+  PACKAGES="./internal/models ./internal/tests/unit" bash scripts/coverage.sh
+  ```
 
 See `scripts/test.cmd help` or `scripts/test.sh help` for all available commands.
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -36,7 +36,9 @@ export NO_AUTO_ANALYZE=true
 export DATABASE_URL="${DATABASE_URL:-postgres://localhost:5432/newsbalancer_test?sslmode=disable}"
 
 # Run tests with coverage
-go test -v -race -coverprofile="$COVERAGE_FILE" -covermode=atomic ./... 2>&1 | tee "$COVERAGE_DIR/test-output.log"
+# Allow specifying packages via PACKAGES env var, defaulting to all packages
+PACKAGES=${PACKAGES:-./...}
+go test -v -race -coverprofile="$COVERAGE_FILE" -covermode=atomic $PACKAGES 2>&1 | tee "$COVERAGE_DIR/test-output.log"
 
 if [ ! -f "$COVERAGE_FILE" ]; then
     echo -e "${RED}Error: Coverage file not generated${NC}"


### PR DESCRIPTION
## Summary
- make coverage script accept custom `PACKAGES` list
- document `PACKAGES` usage in README

## Testing
- `PACKAGES="./internal/models ./internal/tests/unit" bash scripts/coverage.sh`

------
https://chatgpt.com/codex/tasks/task_b_687688a963d88324a69cfb114340b736