### PR TITLE
Increase db coverage with retry tests

### DIFF
--- a/coverage
+++ b/coverage
@@ -1,1 +1,0 @@
-mode: atomic

--- a/internal/db/db_retry_status_test.go
+++ b/internal/db/db_retry_status_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+// helper to open a minimal in-memory DB
+func openStatusTestDB(t *testing.T) *sqlx.DB {
+	db, err := InitDB(":memory:")
+	assert.NoError(t, err)
+	return db
+}
+
+func TestUpdateArticleStatus(t *testing.T) {
+	db := openStatusTestDB(t)
+	defer db.Close()
+
+	article := &Article{
+		Source:  "src",
+		PubDate: time.Now(),
+		URL:     "u1",
+		Title:   "t1",
+		Content: "c1",
+	}
+	id, err := InsertArticle(db, article)
+	assert.NoError(t, err)
+
+	// update status and verify
+	err = UpdateArticleStatus(db, id, "processed")
+	assert.NoError(t, err)
+
+	fetched, err := FetchArticleByID(db, id)
+	assert.NoError(t, err)
+	assert.NotNil(t, fetched.Status)
+	assert.Equal(t, "processed", *fetched.Status)
+
+	// call with non existing id should not error
+	err = UpdateArticleStatus(db, id+9999, "none")
+	assert.NoError(t, err)
+}
+
+func TestWithRetry(t *testing.T) {
+	attempts := 0
+	cfg := RetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond}
+
+	err := WithRetry(cfg, func() error {
+		attempts++
+		if attempts < 2 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+
+	attempts = 0
+	err = WithRetry(cfg, func() error {
+		attempts++
+		return errors.New("database is locked")
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, cfg.MaxAttempts, attempts)
+}

--- a/internal/db/db_sqlmock_test.go
+++ b/internal/db/db_sqlmock_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateArticleScoreRetry(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	query := "UPDATE articles"
+	mock.ExpectExec(query).WithArgs(1.23, 0.45, int64(1)).WillReturnError(fmt.Errorf("database is locked"))
+	mock.ExpectExec(query).WithArgs(1.23, 0.45, int64(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = UpdateArticleScore(db, 1, 1.23, 0.45)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateArticleStatusDBError(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	mock.ExpectExec("UPDATE articles SET status").WithArgs("done", int64(5)).WillReturnError(fmt.Errorf("db error"))
+
+	err = UpdateArticleStatus(db, 5, "done")
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateArticleScoreLLMRetry(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	query := "UPDATE articles"
+	mock.ExpectExec(query).WithArgs(1.0, 0.5, int64(7)).WillReturnError(fmt.Errorf("database is locked"))
+	mock.ExpectExec(query).WithArgs(1.0, 0.5, int64(7)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = UpdateArticleScoreLLM(db, 7, 1.0, 0.5)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateArticleScoreLLMNoRows(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	query := "UPDATE articles"
+	mock.ExpectExec(query).WithArgs(1.0, 0.5, int64(8)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = UpdateArticleScoreLLM(db, 8, 1.0, 0.5)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateArticleScoreLLMError(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	query := "UPDATE articles"
+	mock.ExpectExec(query).WithArgs(1.0, 0.5, int64(9)).WillReturnError(fmt.Errorf("boom"))
+
+	err = UpdateArticleScoreLLM(db, 9, 1.0, 0.5)
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchSourceByIDErrors(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer mockDB.Close()
+
+	mock.ExpectQuery(`SELECT *`).WithArgs(int64(2)).WillReturnError(sql.ErrNoRows)
+	src, err := FetchSourceByID(db, 2)
+	assert.Nil(t, src)
+	assert.EqualError(t, err, "source not found")
+
+	mock.ExpectQuery(`SELECT *`).WithArgs(int64(3)).WillReturnError(fmt.Errorf("fail"))
+	src, err = FetchSourceByID(db, 3)
+	assert.Nil(t, src)
+	assert.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## Summary
- add tests for `UpdateArticleStatus` and retry logic
- cover retry behavior of `UpdateArticleScore` and `UpdateArticleScoreLLM`
- add cases for `FetchSourceByID` errors
- remove obsolete `coverage` file

## Testing
- `go test ./internal/db -coverprofile=coverage/db.out`


------
https://chatgpt.com/codex/tasks/task_b_68772f5afb4c8324b768cf3642d8497b